### PR TITLE
Replace Cadasta repos with appropriate refs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,8 @@ gem "sdoc", "~> 1.0.0", group: :doc
 
 gem "aws-sdk-v1", "~> 1"
 gem "aws-sdk-core", "~> 2"
-gem "aws-ses", :require => 'aws/ses', git: 'https://github.com/Cadasta/aws-ses'
+# also exists as posm/aws-ses#fp-web
+gem "aws-ses", :require => 'aws/ses', git: 'https://github.com/drewblas/aws-ses', ref: 'c1141c4925cad9f742440c995a1378745a34676c'
 gem "bootstrap-sass", "~> 3.3.3"
 gem "composite_primary_keys", "~> 8.0.0"
 gem "devise", "~> 3.5.10" # authentication
@@ -45,7 +46,8 @@ gem "puma" # app server
 gem "rack-contrib"
 gem "rack-rewrite" # URL rewriting middleware
 gem "rails-i18n", "~> 4.0.0"
-gem "s3_direct_upload", git: 'https://github.com/Cadasta/s3_direct_upload'
+# also exists as posm/s3_direct_upload#fp-web
+gem "s3_direct_upload", git: 'https://github.com/waynehoover/s3_direct_upload', ref: 'f8dd8cc03ece607c78ba3befa3270a256eac947c'
 gem "pg"
 gem "workflow"
 gem "json"


### PR DESCRIPTION
The Cadasta repos have gone missing. Fortunately, since a repo's network is stored together by GitHub, the refs still exist (but still needed to be tracked down by looking in an old POSM release)! To avoid these refs being GC'd, I've also forked them to the `posm` organization and created `fp-web` branches for each.

Fixes the Field Papers portion of https://github.com/posm/posm/issues/350

/cc @ian-ross